### PR TITLE
Use global Regex pattern to replace all spaces

### DIFF
--- a/Views/Launch/Details.cshtml
+++ b/Views/Launch/Details.cshtml
@@ -27,7 +27,7 @@ Layout = "_Layout";
 
     innerContainer = document.createElement('div');
       innerContainer.setAttribute("class","row-flex");
-    innerContainer.setAttribute("id",areaTitle+"_"+sectionTitle.replace(' ',''));
+    innerContainer.setAttribute("id",areaTitle+"_"+sectionTitle.replace(/ /g,''));
 
     outputElement.appendChild(headerElement);
     outputElement.appendChild(innerContainer);
@@ -39,10 +39,10 @@ Layout = "_Layout";
     newLink.setAttribute('href',href);
     newLink.setAttribute('target',"_blank");
     newLink.textContent = innerText;
-    document.getElementById(areaTitle+"_"+sectionTitle.replace(' ','')).appendChild(newLink);
+    document.getElementById(areaTitle+"_"+sectionTitle.replace(/ /g,'')).appendChild(newLink);
   }
   function addDivToInfoSection(areaTitle, sectionTitle, divObject){
-    document.getElementById(areaTitle+"_"+sectionTitle.replace(' ','')).appendChild(divObject);
+    document.getElementById(areaTitle+"_"+sectionTitle.replace(/ /g,'')).appendChild(divObject);
   }
   function addItemToInfoSection(areaTitle, sectionTitle, rowHeader, rowData){
     if(rowData == "" || rowData == null) return;
@@ -60,7 +60,7 @@ Layout = "_Layout";
     containerElement = document.createElement('div');
     containerElement.appendChild(headerElement);
     containerElement.appendChild(dataElement);
-    addDivToInfoSection(areaTitle, sectionTitle.replace(' ',''), containerElement);
+    addDivToInfoSection(areaTitle, sectionTitle.replace(/ /g,''), containerElement);
   }
   function addRowToInfoSection(areaTitle, sectionTitle, rowHeader, rowData){
     if(rowData == "" || rowData == null) return;
@@ -79,7 +79,7 @@ Layout = "_Layout";
     containerElement.style.width = "100%";
     containerElement.appendChild(headerElement);
     containerElement.appendChild(dataElement);
-    addDivToInfoSection(areaTitle, sectionTitle.replace(' ',''), containerElement);
+    addDivToInfoSection(areaTitle, sectionTitle.replace(/ /g,''), containerElement);
   }
   var ajaxResults = $.ajax({
     'url': 'https://api.spacexdata.com/v3/launches/@ViewData["id"]',


### PR DESCRIPTION
If `pattern` is a string, only the first occurrence will be replaced. The section header "Type of Object" currently becomes "Typeof Object".

I assume you wanted to remove all spaces. A regular expression can help because it has the global flag `g`. This matches every space:
```
/ /g
```

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace
The deprecation warning for `flags` refers to an unofficial third parameter, not pure regular expressions.